### PR TITLE
Operationalized select and rename, added distinct

### DIFF
--- a/R/dplyr.R
+++ b/R/dplyr.R
@@ -8,23 +8,41 @@ tbl_vars.spark_tbl <- function(x) {
 #' @importFrom dplyr select
 select.spark_tbl <- function(.data, ...) {
   vars <- tidyselect::vars_select(tbl_vars(.data), !!!enquos(...))
-  cols <- lapply(as.list(vars), function(c) {
+
+  # add in grouped columns to the select if not specified
+  groups <- attr(.data, "groups")
+  groups_incl <- groups[!(groups %in% vars)]
+  if (length(groups_incl) > 0) {
+    message("Adding missing grouping variables: `",
+            paste(groups_incl, collapse = "`, `"), "`")
+  }
+  vars_grp <- c(setNames(groups_incl, groups_incl), vars)
+
+  # select the columns
+  cols <- lapply(vars_grp, function(c) {
     new("Column",
         SparkR:::callJStatic("org.apache.spark.sql.functions", "col", c)
         )@jc
     })
   sdf <- SparkR:::callJMethod(attr(.data, "DataFrame")@sdf, "select", cols)
-  sdf <- setNames(new("SparkDataFrame", sdf, F), names(vars))
-  new_spark_tbl(sdf)
+  sdf_named <- setNames(new("SparkDataFrame", sdf, F), names(vars_grp))
+
+  # regroup
+  new_spark_tbl(sdf_named, groups = groups)
 }
 
 #' @export
 #' @importFrom dplyr rename
 rename.spark_tbl <- function(.data, ...) {
-  vars <- tidyselect::vars_select(tbl_vars(.data), !!!enquos(...))
-  sdf <- SparkR::select(attr(.data, "DataFrame"), vars) %>%
-    setNames(names(vars))
-  new_spark_tbl(sdf)
+  vars <- tidyselect::vars_rename(names(.data), !!!enquos(...))
+  cols <- lapply(unclass(vars), function(c) {
+    new("Column",
+        SparkR:::callJStatic("org.apache.spark.sql.functions", "col", c)
+    )@jc
+  })
+  sdf <- SparkR:::callJMethod(attr(.data, "DataFrame")@sdf, "select", cols)
+  sdf <- setNames(new("SparkDataFrame", sdf, F), names(vars))
+  new_spark_tbl(sdf, groups = names(vars[vars %in% attr(.data, "groups")]))
 }
 
 # check to see if a column expression is aggregating

--- a/R/dplyr.R
+++ b/R/dplyr.R
@@ -45,6 +45,36 @@ rename.spark_tbl <- function(.data, ...) {
   new_spark_tbl(sdf, groups = names(vars[vars %in% attr(.data, "groups")]))
 }
 
+#' @distinct
+#' @importFrom dplyr distinct
+distinct.spark_tbl <- function(.data, ...) {
+  # we use the distinct tools from dplyr
+  dist <- dplyr:::distinct_prepare(.data, enquos(...), .keep_all = FALSE)
+  vars <- tbl_vars(.data)[dplyr:::match_vars(dist$vars, dist$data)]
+  # consider adding in .keep_all = T functionality at some point
+  # keep <- dplyr:::match_vars(dist$keep, dist$data)
+
+  # manage the grouping columns
+  groups <- attr(.data, "groups")
+  groups_incl <- groups[!(groups %in% vars)]
+  vars_grp <- c(groups_incl, vars)
+  vars_grp <- setNames(vars_grp, vars_grp)
+
+  # select the columns
+  cols <- lapply(vars_grp, function(c) {
+    new("Column",
+        SparkR:::callJStatic("org.apache.spark.sql.functions", "col", c)
+    )@jc
+  })
+  sdf <- SparkR:::callJMethod(attr(.data, "DataFrame")@sdf, "select", cols)
+  sdf_named <- setNames(new("SparkDataFrame", sdf, F), names(vars_grp))
+
+  # execute distinct
+  sdf_dist <- SparkR:::callJMethod(sdf_named@sdf, "distinct")
+  new_spark_tbl(new("SparkDataFrame", sdf_dist, F), groups = groups)
+
+}
+
 # check to see if a column expression is aggregating
 is_agg_expr <- function(col) {
   if (class(col) %in% c("character", "numeric", "logical")) return(F)

--- a/tests/testthat/test-select-distinct.R
+++ b/tests/testthat/test-select-distinct.R
@@ -1,0 +1,71 @@
+iris_fix <- iris %>%
+  setNames(names(iris) %>% sub("[//.]", "_", .)) %>%
+  mutate(Species = levels(Species)[Species])
+iris_spk <- spark_tbl(iris)
+
+test_that("basic select works", {
+  expect_equal(iris_spk %>%
+                 select(Species, Petal_Width) %>%
+                 collect,
+               iris_fix %>%
+                 select(Species, Petal_Width))
+  expect_equal(iris_spk %>%
+                 select(Sepal_Width, Petal_Width) %>%
+                 collect,
+               iris_fix %>%
+                 select(Sepal_Width, Petal_Width))
+})
+
+test_that("renamed select works", {
+  expect_equal(iris_spk %>%
+                 select(a = Species, b = Petal_Width) %>%
+                 collect,
+               iris_fix %>%
+                 select(a = Species, b = Petal_Width))
+  expect_equal(iris_spk %>%
+                 select(`_54` = Sepal_Width, zz = Petal_Width) %>%
+                 collect,
+               iris_fix %>%
+                 select(`_54` = Sepal_Width, zz = Petal_Width))
+})
+
+test_that("character select works", {
+  expect_equal(iris_spk %>%
+                 select("Species", "Petal_Width") %>%
+                 collect,
+               iris_fix %>%
+                 select("Species", "Petal_Width"))
+  expect_equal(iris_spk %>%
+                 select(c("Sepal_Width", "Petal_Width")) %>%
+                 collect,
+               iris_fix %>%
+                 select(c("Sepal_Width", "Petal_Width")))
+})
+
+test_that("tidyselect works", {
+  expect_equal(iris_spk %>%
+                 select(starts_with("Petal")) %>%
+                 collect,
+               iris_fix %>%
+                 select(starts_with("Petal")))
+  expect_equal(iris_spk %>%
+                 select(matches("dth")) %>%
+                 collect,
+               iris_fix %>%
+                 select(matches("dth")))
+})
+
+test_that("rename works", {
+  expect_equal(iris_spk %>%
+                 rename(a = Species, b = Petal_Width) %>%
+                 collect,
+               iris_fix %>%
+                 rename(a = Species, b = Petal_Width))
+  expect_equal(iris_spk %>%
+                 rename(`_54` = Sepal_Width, zz = Petal_Width) %>%
+                 collect,
+               iris_fix %>%
+                 rename(`_54` = Sepal_Width, zz = Petal_Width))
+})
+
+

--- a/tests/testthat/test-select-distinct.R
+++ b/tests/testthat/test-select-distinct.R
@@ -130,4 +130,21 @@ test_that("basic distinct works", {
                  distinct)
 })
 
+test_that("grouped distinct works", {
+  expect_equal(iris_spk %>%
+                 group_by(Species) %>%
+                 distinct(Petal_Width) %>%
+                 collect,
+               iris_fix %>%
+                 group_by(Species) %>%
+                 distinct(Petal_Width))
+  expect_equal(iris_spk %>%
+                 group_by(Species) %>%
+                 distinct %>%
+                 collect,
+               iris_fix %>%
+                 group_by(Species) %>%
+                 distinct)
+})
+
 

--- a/tests/testthat/test-select-distinct.R
+++ b/tests/testthat/test-select-distinct.R
@@ -55,6 +55,30 @@ test_that("tidyselect works", {
                  select(matches("dth")))
 })
 
+test_that("grouped select works", {
+  expect_equal(iris_spk %>%
+                 group_by(Species) %>%
+                 select(Petal_Width) %>%
+                 collect,
+               iris_fix %>%
+                 group_by(Species) %>%
+                 select(Petal_Width))
+  expect_equal(iris_spk %>%
+                 group_by(Species) %>%
+                 select(Petal_Width, Species) %>%
+                 collect,
+               iris_fix %>%
+                 group_by(Species) %>%
+                 select(Petal_Width, Species))
+  expect_equal(iris_spk %>%
+                 group_by(Species) %>%
+                 select(Petal_Width, derp = Species) %>%
+                 collect,
+               iris_fix %>%
+                 group_by(Species) %>%
+                 select(Petal_Width, derp = Species))
+})
+
 test_that("rename works", {
   expect_equal(iris_spk %>%
                  rename(a = Species, b = Petal_Width) %>%
@@ -66,6 +90,44 @@ test_that("rename works", {
                  collect,
                iris_fix %>%
                  rename(`_54` = Sepal_Width, zz = Petal_Width))
+})
+
+test_that("rename works when a df is grouped", {
+  expect_equal(iris_spk %>%
+                 group_by(Species) %>%
+                 rename(a = Petal_Width) %>%
+                 collect,
+               iris_fix %>%
+                 group_by(Species) %>%
+                 rename(a = Petal_Width))
+  expect_equal(iris_spk %>%
+                 group_by(Species) %>%
+                 rename(a = Petal_Width, boop = Species) %>%
+                 collect,
+               iris_fix %>%
+                 group_by(Species) %>%
+                 rename(a = Petal_Width, boop = Species))
+  expect_equal(iris_spk %>%
+                 group_by(Species) %>%
+                 rename(a = Petal_Width) %>%
+                 attr("groups"), "Species")
+  expect_equal(iris_spk %>%
+                 group_by(Species) %>%
+                 rename(a = Petal_Width, boop = Species) %>%
+                 attr("groups"), "boop")
+})
+
+test_that("basic distinct works", {
+  expect_equal(iris_spk %>%
+                 distinct(Species) %>%
+                 collect,
+               iris_fix %>%
+                 distinct(Species))
+  expect_equal(iris_spk %>%
+                 distinct %>%
+                 collect,
+               iris_fix %>%
+                 distinct)
 })
 
 


### PR DESCRIPTION
`select` and `rename` were some of the first verbs implemented. I re-visited these and get rid of their SparkR dependance as well as added support for grouping columns and various edge cases. `rename` actually was not functioning correctly; it was more of an alias for `select` as it would remove unspecified columns. Now it is fixed. I added a comprehensive test suite as part of a TDD approach to get these onboard.

I also went ahead and added similar support for `distinct` as it has such a similar structure to `select`, except that the input is not as flexible and it has a Java `distinct` call at the tail end. All of the corrections to `select` and `rename` took maybe 2.5 hours, and getting `distinct` built and tested was only 20-30 minutes.